### PR TITLE
Exception in thread "main" java.lang.IllegalAccessError: in-seconds does not exist

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,6 @@
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [ring/ring-core "1.2.0"]
                  [ring-mock "0.1.5"]
-                 [clj-time "0.5.1"]]
+                 [clj-time "0.6.0"]]
   :profiles {:dev {:dependencies [[compojure "1.1.5"]]}})
 


### PR DESCRIPTION
The plugin doesn't work with the current version of ring. 
If I try to use it, I get the following exception:

```
Exception in thread "main" java.lang.IllegalAccessError: in-seconds does not exist, compiling:(ring/middleware/cookies.clj:1:1`)
```

Upgrading `clj-time` to version `0.6.0` (which is used by ring) fixes the problem. 
